### PR TITLE
Fix cnd export

### DIFF
--- a/src/ConnectionMatcher.cpp
+++ b/src/ConnectionMatcher.cpp
@@ -426,18 +426,19 @@ cnd::model::Network ConnectionMatcher::generateNetwork()
         net.addTask(cndTask);
         
         // Create or find deployment for the task
-        auto it = deploymentMap.find(t.name);
+        std::string depUID(t.hostname + std::to_string(t.pid));
+        auto it = deploymentMap.find(depUID);
         if(it == deploymentMap.end())
         {
             // When we have distributed deployments, we use the hostname,pid pair to generate a UID for deployments
-            cnd::model::Deployment depl = cnd::model::Deployment(t.hostname + std::to_string(t.pid));
+            cnd::model::Deployment depl = cnd::model::Deployment(depUID);
             depl.setDeployer("orogen");
             depl.setHostID(t.hostname);
             depl.setProcessName(t.deployment);
             std::map<std::string, std::string> taskList;
             taskList[t.name] = t.command;
             depl.setTaskList(taskList);
-            deploymentMap.insert(std::make_pair(t.name,  depl));
+            deploymentMap.insert(std::make_pair(depUID,  depl));
         }
         else
         {

--- a/src/ConnectionMatcher.cpp
+++ b/src/ConnectionMatcher.cpp
@@ -52,6 +52,7 @@ void ConnectionMatcher::createGraph()
         task->deployment = taskData.taskDeployment;
         task->command = taskData.taskCommand;
         task->pid = taskData.taskPid;
+        task->hostname = taskData.taskHost;
         curIndent += 4;
         for(const PortData &pd: taskData.portData)
         {
@@ -431,9 +432,10 @@ cnd::model::Network ConnectionMatcher::generateNetwork()
         auto it = deploymentMap.find(t.pid);
         if(it == deploymentMap.end())
         {
-            cnd::model::Deployment depl = cnd::model::Deployment(std::to_string(t.pid));
+            // When we have distributed deployments, we use the hostname,pid pair to generate a UID for deployments
+            cnd::model::Deployment depl = cnd::model::Deployment(t.hostname + std::to_string(t.pid));
             depl.setDeployer("orogen");
-            depl.setHostID("localhost");
+            depl.setHostID(t.hostname);
             depl.setProcessName(t.deployment);
             std::map<std::string, std::string> taskList;
             taskList[t.name] = t.command;

--- a/src/ConnectionMatcher.cpp
+++ b/src/ConnectionMatcher.cpp
@@ -406,11 +406,8 @@ void addConnectionWithOut(cnd::model::Connection* con, const ChannelBase *ce, co
 
 cnd::model::Network ConnectionMatcher::generateNetwork()
 {
-    
-    std::map<int,cnd::model::Connection> connectionMap;
-    
-    std::map<int,cnd::model::Deployment> deploymentMap;
-    
+    // Use task uid (which coincides with its name) to resolve deployment membership
+    std::map<std::string,cnd::model::Deployment> deploymentMap;
     int id = 0;
     
     for(const Task &t: tasks)
@@ -428,8 +425,8 @@ cnd::model::Network ConnectionMatcher::generateNetwork()
         
         net.addTask(cndTask);
         
-        
-        auto it = deploymentMap.find(t.pid);
+        // Create or find deployment for the task
+        auto it = deploymentMap.find(t.name);
         if(it == deploymentMap.end())
         {
             // When we have distributed deployments, we use the hostname,pid pair to generate a UID for deployments
@@ -440,7 +437,7 @@ cnd::model::Network ConnectionMatcher::generateNetwork()
             std::map<std::string, std::string> taskList;
             taskList[t.name] = t.command;
             depl.setTaskList(taskList);
-            deploymentMap.insert(std::make_pair(t.pid,  depl));
+            deploymentMap.insert(std::make_pair(t.name,  depl));
         }
         else
         {
@@ -450,12 +447,11 @@ cnd::model::Network ConnectionMatcher::generateNetwork()
                 taskList[t.name] = t.command;
                 it->second.setTaskList(taskList);
             }
-            
         }
         
+        // Cycle through output ports of the task and find other possible ports connected to them
         for(const OutputPort *op: t.outputPorts)
         {
-    
             for(const Connection con:op->connections)
             {
                 bool connected = false;

--- a/src/ConnectionMatcher.hpp
+++ b/src/ConnectionMatcher.hpp
@@ -78,6 +78,7 @@ public:
     std::string type;
     std::string state;
     std::string deployment;
+    std::string hostname;
     TaskActivity activity;
     
     std::vector<InputPort *> inputPorts;

--- a/src/IntrospectionService.cpp
+++ b/src/IntrospectionService.cpp
@@ -55,6 +55,11 @@ TaskData IntrospectionService::getIntrospectionInformation()
     
     TaskData taskData;
     taskData.taskName = task->getName();
+
+    // Get the hostname of the running system
+    char hostName[256];
+    gethostname(hostName, 256);
+    taskData.taskHost = std::string(hostName);
     
     taskData.taskDeployment = get_process_name_by_pid(getpid());
     taskData.taskCommand = task->engine()->getThread()->getName();

--- a/src/IntrospectionTypes.hpp
+++ b/src/IntrospectionTypes.hpp
@@ -82,6 +82,8 @@ public:
     TaskActivity taskActivity;
     
     std::string taskDeployment;
+
+    std::string taskHost;
 };
 
 }


### PR DESCRIPTION
This fork fixes the following issues:
* The connections have not been correctly resolved when exporting a CND model
* Introspection was not able to retrieve the hostnames of the machines the tasks were running on
* Therefore, deployments could not identified uniquely across machines and their hostnames were not set properly

These fixes have been tested with a newly developed component CNDMonitor which is available
in DFKI D-ROCK repos