### PR TITLE
Add dependency to rtt_introspection_matcher that was fulfilled elsewhere

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,6 +19,8 @@ rock_library(rtt_introspection
 rock_library(rtt_introspection_matcher
     SOURCES ConnectionMatcher.cpp
     HEADERS ConnectionMatcher.hpp
+    DEPS_PKGCONFIG
+        orocos-rtt-${OROCOS_TARGET}
 )
 
 rock_executable(rtt_introspection_bin Main.cpp


### PR DESCRIPTION
rtt_introspection_matcher requires orocos-rtt-${OROCOS_TARGET}, but does not mention it. By rtt_introspection being set up earlier, the required include directories still can be found. This breaks when changing target order or commenting parts of this CMakeLists.txt.

@maltewi i can do the merge if you are ok with that.